### PR TITLE
Add signup link to "Get Started" button in header (#15)

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -32,9 +32,11 @@ export default function Header() {
             <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
             <span className="sr-only">Toggle theme</span>
           </Button>
-          <Button className="hidden sm:inline-flex bg-gray-800 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200">
-            Get Started
-          </Button>
+          <Link href="/auth/signup" passHref legacyBehavior>
+            <Button className="hidden sm:inline-flex bg-gray-800 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200">
+              Get Started
+            </Button>
+          </Link>
         </div>
       </div>
     </header>


### PR DESCRIPTION
Updated the "Get Started" button in the header to navigate to the signup page using Next.js Link component for better accessibility and performance.

- Wrapped button with Next.js Link component
- Points to /auth/signup route
- Maintains existing styling and functionality