### PR TITLE
Fix invoice button redirection

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -252,6 +252,7 @@ export default function DashboardPage() {
               <Link 
                 href="/invoices/new"
                 className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors flex items-center justify-center"
+                title="Create a new invoice (opens form)"
               >
                 Create Invoice
               </Link>

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -79,13 +79,15 @@ export default function InvoiceViewPage() {
     console.log('Invoice view page loaded - invoiceId:', invoiceId)
     console.log('showEmailDialog initial state:', showEmailDialog)
     console.log('Current URL:', typeof window !== 'undefined' ? window.location.href : 'N/A')
-  }, [invoiceId])
+  }, [invoiceId, showEmailDialog])
 
-  // Ensure showEmailDialog is always false on component mount and handle URL parameters
+  // Ensure showEmailDialog is always false on component mount
   useEffect(() => {
     setShowEmailDialog(false)
-    
-    // Clear any URL parameters that might be causing issues
+  }, [])
+
+  // Clear any URL parameters that might be causing issues
+  useEffect(() => {
     if (typeof window !== 'undefined' && window.history.replaceState) {
       const url = new URL(window.location.href)
       let hasProblematicParams = false
@@ -120,7 +122,7 @@ export default function InvoiceViewPage() {
     }, 100)
     
     return () => clearTimeout(timer)
-  }, [])
+  }, [showEmailDialog]) // Include showEmailDialog since we're reading its value
 
   useEffect(() => {
     const fetchInvoice = async () => {

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -347,7 +347,7 @@ export default function InvoicesPage() {
                       <Link
                         href={`/invoices/${invoice.id}`}
                         className="text-gray-600 hover:text-gray-900"
-                        title="View Invoice"
+                        title="View Invoice Details (does not send)"
                       >
                         <Eye className="w-4 h-4" />
                       </Link>
@@ -454,6 +454,7 @@ export default function InvoicesPage() {
                       <Link
                         href={`/invoices/${invoice.id}`}
                         className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+                        title="View invoice details (does not send email)"
                       >
                         View Details
                       </Link>

--- a/src/components/invoices/Actions.tsx
+++ b/src/components/invoices/Actions.tsx
@@ -1,6 +1,5 @@
 import { Send, DollarSign } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { useState } from 'react'
 
 type ActionsProps = {
   status: string
@@ -12,8 +11,6 @@ type ActionsProps = {
 }
 
 export default function Actions({ status, sendingInvoice, markingPaid, onSend, onMarkAsPaid, updatedAt }: ActionsProps) {
-  const [showSendConfirmation, setShowSendConfirmation] = useState(false)
-
   const handleSendClick = () => {
     // Add confirmation to prevent accidental sending
     if (window.confirm('Are you sure you want to send this invoice via email? This will open the email form.')) {

--- a/src/components/invoices/Actions.tsx
+++ b/src/components/invoices/Actions.tsx
@@ -1,5 +1,6 @@
 import { Send, DollarSign } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useState } from 'react'
 
 type ActionsProps = {
   status: string
@@ -11,6 +12,15 @@ type ActionsProps = {
 }
 
 export default function Actions({ status, sendingInvoice, markingPaid, onSend, onMarkAsPaid, updatedAt }: ActionsProps) {
+  const [showSendConfirmation, setShowSendConfirmation] = useState(false)
+
+  const handleSendClick = () => {
+    // Add confirmation to prevent accidental sending
+    if (window.confirm('Are you sure you want to send this invoice via email? This will open the email form.')) {
+      onSend()
+    }
+  }
+
   return (
     <div className="bg-white shadow rounded-lg p-6">
       <div className="flex justify-between items-center">
@@ -19,13 +29,23 @@ export default function Actions({ status, sendingInvoice, markingPaid, onSend, o
         </div>
         <div className="flex space-x-3">
           {status === 'draft' && (
-            <Button onClick={onSend} disabled={sendingInvoice} className="inline-flex items-center">
+            <Button 
+              onClick={handleSendClick} 
+              disabled={sendingInvoice} 
+              className="inline-flex items-center"
+              title="Send this invoice via email to the client"
+            >
               <Send className="w-4 h-4 mr-2" />
-              {sendingInvoice ? 'Sending...' : 'Send Invoice'}
+              {sendingInvoice ? 'Sending...' : 'Email Invoice'}
             </Button>
           )}
           {status !== 'paid' && (
-            <Button onClick={onMarkAsPaid} disabled={markingPaid} className="inline-flex items-center bg-green-600 hover:bg-green-700">
+            <Button 
+              onClick={onMarkAsPaid} 
+              disabled={markingPaid} 
+              className="inline-flex items-center bg-green-600 hover:bg-green-700"
+              title="Mark this invoice as paid"
+            >
               <DollarSign className="w-4 h-4 mr-2" />
               {markingPaid ? 'Marking...' : 'Mark as Paid'}
             </Button>

--- a/src/components/invoices/Actions.tsx
+++ b/src/components/invoices/Actions.tsx
@@ -12,11 +12,32 @@ type ActionsProps = {
 
 export default function Actions({ status, sendingInvoice, markingPaid, onSend, onMarkAsPaid, updatedAt }: ActionsProps) {
   const handleSendClick = () => {
+    console.log('🚨 Send Invoice button clicked!', { status, sendingInvoice })
+    
     // Add confirmation to prevent accidental sending
-    if (window.confirm('Are you sure you want to send this invoice via email? This will open the email form.')) {
+    const userConfirmed = window.confirm(
+      `Are you sure you want to send this ${status} invoice via email?\n\n` +
+      'This will:\n' +
+      '• Open the email form\n' +
+      '• Allow you to customize the message\n' +
+      '• Send the invoice to the client\n\n' +
+      'Click OK to continue or Cancel to go back.'
+    )
+    
+    if (userConfirmed) {
+      console.log('✅ User confirmed - opening email dialog')
       onSend()
+    } else {
+      console.log('❌ User cancelled - staying on view page')
     }
   }
+
+  const handleMarkAsPaidClick = () => {
+    console.log('💰 Mark as Paid button clicked!', { status, markingPaid })
+    onMarkAsPaid()
+  }
+
+  console.log('🔧 Actions component rendered:', { status, sendingInvoice, markingPaid })
 
   return (
     <div className="bg-white shadow rounded-lg p-6">
@@ -29,16 +50,16 @@ export default function Actions({ status, sendingInvoice, markingPaid, onSend, o
             <Button 
               onClick={handleSendClick} 
               disabled={sendingInvoice} 
-              className="inline-flex items-center"
-              title="Send this invoice via email to the client"
+              className="inline-flex items-center bg-blue-600 hover:bg-blue-700"
+              title="Send this invoice via email to the client (requires confirmation)"
             >
               <Send className="w-4 h-4 mr-2" />
-              {sendingInvoice ? 'Sending...' : 'Email Invoice'}
+              {sendingInvoice ? 'Sending...' : '📧 Email Invoice'}
             </Button>
           )}
           {status !== 'paid' && (
             <Button 
-              onClick={onMarkAsPaid} 
+              onClick={handleMarkAsPaidClick} 
               disabled={markingPaid} 
               className="inline-flex items-center bg-green-600 hover:bg-green-700"
               title="Mark this invoice as paid"
@@ -48,6 +69,11 @@ export default function Actions({ status, sendingInvoice, markingPaid, onSend, o
             </Button>
           )}
         </div>
+      </div>
+      
+      {/* Status indicator for debugging */}
+      <div className="mt-2 text-xs text-gray-400">
+        Status: {status} | Actions available: {status === 'draft' ? 'Email Invoice' : ''} {status !== 'paid' ? 'Mark as Paid' : ''}
       </div>
     </div>
   )


### PR DESCRIPTION
Clarify invoice action buttons and prevent the email dialog from opening unexpectedly.

Users reported that clicking "View Invoice" or "Create Invoice" sometimes led to the "Send Invoice" form (EmailDialog) opening. This was due to either problematic URL parameters automatically triggering the dialog or accidental clicks on the "Send Invoice" button. This PR enhances URL parameter clearing, renames the "Send Invoice" button to "Email Invoice" with a confirmation step, and adds clarifying tooltips to various invoice-related buttons and links.